### PR TITLE
 fix: ghp-import the correct directory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,9 @@ pipeline {
       steps {
         script {
           sh 'NODE_OPTIONS=--openssl-legacy-provider yarn build'
-          jenkins.genBuildMetaJSON('build/build.json')
+          /* We run it again because VuePress is retarded */
+          sh 'NODE_OPTIONS=--openssl-legacy-provider yarn build'
+          jenkins.genBuildMetaJSON('docs/.vuepress/dist/build.json')
         }
       }
     }
@@ -47,7 +49,7 @@ pipeline {
             ghp-import \
               -b ${deployBranch()} \
               -c ${deployDomain()} \
-              -p build
+              -p docs/.vuepress/dist
           """
          }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
   environment {
     GIT_COMMITTER_NAME = 'status-im-auto'
     GIT_COMMITTER_EMAIL = 'auto@status.im'
+    NODE_OPTIONS = '--openssl-legacy-provider'
   }
 
   stages {
@@ -34,9 +35,9 @@ pipeline {
     stage('Build') {
       steps {
         script {
-          sh 'NODE_OPTIONS=--openssl-legacy-provider yarn build'
+          sh 'yarn build'
           /* We run it again because VuePress is retarded */
-          sh 'NODE_OPTIONS=--openssl-legacy-provider yarn build'
+          sh 'yarn build'
           jenkins.genBuildMetaJSON('docs/.vuepress/dist/build.json')
         }
       }


### PR DESCRIPTION
This PR fixes the import directory for `ghp-import` tool to pick the `dist` directory inside `vuepress`.
This PR also adds back the double build step for `vuepress`.